### PR TITLE
Remove reviewers from Dependabot configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @arnested

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,19 +6,13 @@ updates:
     schedule:
       interval: daily
       timezone: Europe/Copenhagen
-    reviewers:
-      - arnested
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
       timezone: Europe/Copenhagen
-    reviewers:
-      - arnested
   - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: daily
       timezone: Europe/Copenhagen
-    reviewers:
-      - arnested


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

<!--
Please describe the bug fix or feature you would like to introduce.
-->
