### PR TITLE
Test Go unstable version 1.25rc3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module arnested.dk/go/fetch-ssh-keys
 
-go 1.24.6
+go 1.25rc3
 
 require (
 	github.com/carlmjohnson/versioninfo v0.22.5


### PR DESCRIPTION
Test Go unstable version 1.25rc3.

See [the draft release notes](https://tip.golang.org/doc/go1.25).

This pull request is only intented for getting feedback on compatibility with future Go versions. Don't merge it!